### PR TITLE
Fix cayman islands dial code

### DIFF
--- a/lib/src/models/country_list.dart
+++ b/lib/src/models/country_list.dart
@@ -328,7 +328,7 @@ class Countries {
       "alpha_3_code": "CYM",
       "en_short_name": "Cayman Islands",
       "nationality": "Caymanian",
-      "dial_code": "+ 345"
+      "dial_code": "+1345"
     },
     {
       "num_code": "140",


### PR DESCRIPTION
The dial code in cayman should have the prefix +1