### PR TITLE
Remove regex for parsing number

### DIFF
--- a/lib/src/utils/phone_number.dart
+++ b/lib/src/utils/phone_number.dart
@@ -79,7 +79,7 @@ class PhoneNumber extends Equatable {
   String parseNumber() {
     return this
         .phoneNumber
-        .replaceAll(RegExp('^([\\+]?${this.dialCode}[\\s]?)'), '');
+        .replaceAll(RegExp('${this.dialCode}', '');
   }
 
   /// For predefined phone number returns Country's [isoCode] from the dial code,


### PR DESCRIPTION
This regex check fails when the user selects the country code without entering the phone number. We can directly replace the code with an empty string.