### PR TITLE
Add alpha3Code to the the selector-search criteria

### DIFF
--- a/lib/src/models/country_model.dart
+++ b/lib/src/models/country_model.dart
@@ -7,8 +7,11 @@ class Country {
   /// The name of the [Country]
   final String name;
 
-  /// The isoCode of the [Country]
-  final String countryCode;
+  /// The alpha 2 isoCode of the [Country]
+  final String alpha2Code;
+
+  /// The alpha 3 isoCode of the [Country]
+  final String alpha3Code;
 
   /// The dialCode of the [Country]
   final String dialCode;
@@ -21,7 +24,8 @@ class Country {
 
   Country({
     @required this.name,
-    @required this.countryCode,
+    @required this.alpha2Code,
+    @required this.alpha3Code,
     @required this.dialCode,
     @required this.flagUri,
     this.nameTranslations,
@@ -31,7 +35,8 @@ class Country {
   factory Country.fromJson(Map<String, dynamic> data) {
     return Country(
       name: data['en_short_name'],
-      countryCode: data['alpha_2_code'],
+      alpha2Code: data['alpha_2_code'],
+      alpha3Code: data['alpha_3_code'],
       dialCode: data['dial_code'],
       flagUri: 'assets/flags/${data['alpha_2_code'].toLowerCase()}.png',
       nameTranslations: data['nameTranslations'] != null

--- a/lib/src/utils/selector_config.dart
+++ b/lib/src/utils/selector_config.dart
@@ -1,4 +1,10 @@
+import 'package:intl_phone_number_input/src/models/country_model.dart';
 import 'package:intl_phone_number_input/src/widgets/input_widget.dart';
+
+/// [CountryComparator] takes two countries: A and B.
+///
+/// Should return -1 if A precedes B, 0 if A is equal to B and 1 if B precedes A
+typedef CountryComparator = int Function(Country, Country);
 
 /// [SelectorConfig] contains selector button configurations
 class SelectorConfig {
@@ -12,9 +18,15 @@ class SelectorConfig {
   /// [useEmoji], uses emoji flags instead of png assets
   final bool useEmoji;
 
+  /// [countryComparator], sort the country list according to the comparator.
+  ///
+  /// Sorting is disabled by default
+  final CountryComparator countryComparator;
+
   const SelectorConfig({
     this.selectorType = PhoneInputSelectorType.DROPDOWN,
     this.showFlags = true,
     this.useEmoji = false,
+    this.countryComparator,
   });
 }

--- a/lib/src/utils/util.dart
+++ b/lib/src/utils/util.dart
@@ -6,7 +6,7 @@ class Utils {
   ///  Returns the first [Country] in the list if no match is available.
   static Country getInitialSelectedCountry(
       List<Country> countries, String countryCode) {
-    return countries.firstWhere((country) => country.countryCode == countryCode,
+    return countries.firstWhere((country) => country.alpha2Code == countryCode,
         orElse: () => countries[0]);
   }
 

--- a/lib/src/widgets/countries_search_list_widget.dart
+++ b/lib/src/widgets/countries_search_list_widget.dart
@@ -52,6 +52,9 @@ class _CountrySearchListWidgetState extends State<CountrySearchListWidget> {
       return widget.countries
           .where(
             (Country country) =>
+                country.alpha3Code
+                    .toLowerCase()
+                    .startsWith(value.toLowerCase()) ||
                 country.name.toLowerCase().contains(value.toLowerCase()) ||
                 getCountryName(country)
                     .toLowerCase()
@@ -99,7 +102,7 @@ class _CountrySearchListWidgetState extends State<CountrySearchListWidget> {
               Country country = filteredCountries[index];
               if (country == null) return null;
               return ListTile(
-                key: Key(TestHelper.countryItemKeyValue(country.countryCode)),
+                key: Key(TestHelper.countryItemKeyValue(country.alpha2Code)),
                 leading: widget.showFlags
                     ? _Flag(country: country, useEmoji: widget.useEmoji)
                     : null,
@@ -134,7 +137,7 @@ class _Flag extends StatelessWidget {
         ? Container(
             child: useEmoji
                 ? Text(
-                    Utils.generateFlagEmojiUnicode(country?.countryCode ?? ''),
+                    Utils.generateFlagEmojiUnicode(country?.alpha2Code ?? ''),
                     style: Theme.of(context).textTheme.headline5,
                   )
                 : country?.flagUri != null

--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -173,6 +173,12 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
       List<Country> countries =
           CountryProvider.getCountriesData(countries: widget.countries);
 
+      final CountryComparator countryComparator =
+          widget.selectorConfig?.countryComparator;
+      if (countryComparator != null) {
+        countries.sort(countryComparator);
+      }
+
       Country country = Utils.getInitialSelectedCountry(
         countries,
         widget.initialValue?.isoCode ?? '',

--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -189,7 +189,7 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
       String parsedPhoneNumberString =
           controller.text.replaceAll(RegExp(r'[^\d+]'), '');
 
-      getParsedPhoneNumber(parsedPhoneNumberString, this.country?.countryCode)
+      getParsedPhoneNumber(parsedPhoneNumberString, this.country?.alpha2Code)
           .then((phoneNumber) {
         if (phoneNumber == null) {
           String phoneNumber =
@@ -198,7 +198,7 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
           if (widget.onInputChanged != null) {
             widget.onInputChanged(PhoneNumber(
                 phoneNumber: phoneNumber,
-                isoCode: this.country?.countryCode,
+                isoCode: this.country?.alpha2Code,
                 dialCode: this.country?.dialCode));
           }
 
@@ -210,7 +210,7 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
           if (widget.onInputChanged != null) {
             widget.onInputChanged(PhoneNumber(
                 phoneNumber: phoneNumber,
-                isoCode: this.country?.countryCode,
+                isoCode: this.country?.alpha2Code,
                 dialCode: this.country?.dialCode));
           }
 
@@ -297,7 +297,7 @@ class _InputWidgetView
 
   @override
   Widget build(BuildContext context) {
-    final countryCode = state?.country?.countryCode ?? '';
+    final countryCode = state?.country?.alpha2Code ?? '';
     final dialCode = state?.country?.dialCode ?? '';
 
     return Container(

--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -155,7 +155,10 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
   void initialiseWidget() async {
     if (widget.initialValue != null) {
       if (widget.initialValue.phoneNumber != null &&
-          widget.initialValue.phoneNumber.isNotEmpty) {
+          widget.initialValue.phoneNumber.isNotEmpty &&
+          await PhoneNumberUtil.isValidPhoneNumber(
+              phoneNumber: widget.initialValue.phoneNumber,
+              isoCode: widget.initialValue.isoCode)) {
         controller.text =
             await PhoneNumber.getParsableNumber(widget.initialValue);
 

--- a/lib/src/widgets/item.dart
+++ b/lib/src/widgets/item.dart
@@ -56,7 +56,7 @@ class _Flag extends StatelessWidget {
         ? Container(
             child: useEmoji
                 ? Text(
-                    Utils.generateFlagEmojiUnicode(country?.countryCode ?? ''),
+                    Utils.generateFlagEmojiUnicode(country?.alpha2Code ?? ''),
                     style: Theme.of(context).textTheme.headline5,
                   )
                 : country?.flagUri != null

--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -96,7 +96,7 @@ class SelectorButton extends StatelessWidget {
       return DropdownMenuItem<Country>(
         value: country,
         child: Item(
-          key: Key(TestHelper.countryItemKeyValue(country.countryCode)),
+          key: Key(TestHelper.countryItemKeyValue(country.alpha2Code)),
           country: country,
           showFlag: selectorConfig.showFlags,
           useEmoji: selectorConfig.useEmoji,

--- a/test/intl_phone_country_list_test.dart
+++ b/test/intl_phone_country_list_test.dart
@@ -9,6 +9,22 @@ void main() {
     test('Json is correctly loaded in to memory', () async {
       expect(Countries.countryList.length, greaterThan(0));
 
+      const List<String> expectedTranslations = [
+        'sk',
+        'se',
+        'pl',
+        'no',
+        'ja',
+        'it',
+        'zh',
+        'nl',
+        'de',
+        'fr',
+        'en',
+        'es',
+        'pt_BR',
+      ];
+
       Countries.countryList.forEach((Map<String, dynamic> data) {
         Country country = Country.fromJson(data);
 
@@ -17,20 +33,10 @@ void main() {
         expect(country.alpha3Code.length, greaterThan(0));
         expect(country.dialCode.length, greaterThan(0));
         expect(country.flagUri.length, greaterThan(0));
-        expect(country.nameTranslations.length, equals(12));
-
-        expect(country.nameTranslations.containsKey('sk'), true);
-        expect(country.nameTranslations.containsKey('se'), true);
-        expect(country.nameTranslations.containsKey('pl'), true);
-        expect(country.nameTranslations.containsKey('no'), true);
-        expect(country.nameTranslations.containsKey('ja'), true);
-        expect(country.nameTranslations.containsKey('it'), true);
-        expect(country.nameTranslations.containsKey('zh'), true);
-        expect(country.nameTranslations.containsKey('nl'), true);
-        expect(country.nameTranslations.containsKey('de'), true);
-        expect(country.nameTranslations.containsKey('fr'), true);
-        expect(country.nameTranslations.containsKey('en'), true);
-        expect(country.nameTranslations.containsKey('es'), true);
+        expect(country.nameTranslations.length,
+            equals(expectedTranslations.length));
+        expectedTranslations.forEach((language) =>
+            expect(country.nameTranslations.containsKey(language), true));
       });
     });
   });

--- a/test/intl_phone_country_list_test.dart
+++ b/test/intl_phone_country_list_test.dart
@@ -13,7 +13,8 @@ void main() {
         Country country = Country.fromJson(data);
 
         expect(country.name.length, greaterThan(0));
-        expect(country.countryCode.length, greaterThan(0));
+        expect(country.alpha2Code.length, greaterThan(0));
+        expect(country.alpha3Code.length, greaterThan(0));
         expect(country.dialCode.length, greaterThan(0));
         expect(country.flagUri.length, greaterThan(0));
         expect(country.nameTranslations.length, equals(12));


### PR DESCRIPTION
I renamed the `Country.countryCode` to `alpha2Code`.
The search criteria I added matches any country where the `Country.alpha3Code` starts with the users search query.
For example: USA matches United States of America.