### PR TITLE
Fix and refactor the 'Countries are loaded' test

### DIFF
--- a/test/intl_phone_country_list_test.dart
+++ b/test/intl_phone_country_list_test.dart
@@ -9,6 +9,22 @@ void main() {
     test('Json is correctly loaded in to memory', () async {
       expect(Countries.countryList.length, greaterThan(0));
 
+      const List<String> expectedTranslations = [
+        'sk',
+        'se',
+        'pl',
+        'no',
+        'ja',
+        'it',
+        'zh',
+        'nl',
+        'de',
+        'fr',
+        'en',
+        'es',
+        'pt_BR',
+      ];
+
       Countries.countryList.forEach((Map<String, dynamic> data) {
         Country country = Country.fromJson(data);
 
@@ -16,20 +32,10 @@ void main() {
         expect(country.countryCode.length, greaterThan(0));
         expect(country.dialCode.length, greaterThan(0));
         expect(country.flagUri.length, greaterThan(0));
-        expect(country.nameTranslations.length, equals(12));
-
-        expect(country.nameTranslations.containsKey('sk'), true);
-        expect(country.nameTranslations.containsKey('se'), true);
-        expect(country.nameTranslations.containsKey('pl'), true);
-        expect(country.nameTranslations.containsKey('no'), true);
-        expect(country.nameTranslations.containsKey('ja'), true);
-        expect(country.nameTranslations.containsKey('it'), true);
-        expect(country.nameTranslations.containsKey('zh'), true);
-        expect(country.nameTranslations.containsKey('nl'), true);
-        expect(country.nameTranslations.containsKey('de'), true);
-        expect(country.nameTranslations.containsKey('fr'), true);
-        expect(country.nameTranslations.containsKey('en'), true);
-        expect(country.nameTranslations.containsKey('es'), true);
+        expect(country.nameTranslations.length,
+            equals(expectedTranslations.length));
+        expectedTranslations.forEach((language) =>
+            expect(country.nameTranslations.containsKey(language), true));
       });
     });
   });


### PR DESCRIPTION
There now are 13 translations.
I put the list in a constant so we can easily add new translation languages to it.