### PR TITLE
Add countryComparator to SelectorConfig

### DIFF
--- a/lib/src/utils/selector_config.dart
+++ b/lib/src/utils/selector_config.dart
@@ -1,4 +1,10 @@
+import 'package:intl_phone_number_input/src/models/country_model.dart';
 import 'package:intl_phone_number_input/src/widgets/input_widget.dart';
+
+/// [CountryComparator] takes two countries: A and B.
+///
+/// Should return -1 if A precedes B, 0 if A is equal to B and 1 if B precedes A
+typedef CountryComparator = int Function(Country, Country);
 
 /// [SelectorConfig] contains selector button configurations
 class SelectorConfig {
@@ -12,9 +18,15 @@ class SelectorConfig {
   /// [useEmoji], uses emoji flags instead of png assets
   final bool useEmoji;
 
+  /// [countryComparator], sort the country list according to the comparator.
+  ///
+  /// Sorting is disabled by default
+  final CountryComparator countryComparator;
+
   const SelectorConfig({
     this.selectorType = PhoneInputSelectorType.DROPDOWN,
     this.showFlags = true,
     this.useEmoji = false,
+    this.countryComparator,
   });
 }

--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -170,6 +170,12 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
       List<Country> countries =
           CountryProvider.getCountriesData(countries: widget.countries);
 
+      final CountryComparator countryComparator =
+          widget.selectorConfig?.countryComparator;
+      if (countryComparator != null) {
+        countries.sort(countryComparator);
+      }
+
       Country country = Utils.getInitialSelectedCountry(
         countries,
         widget.initialValue?.isoCode ?? '',


### PR DESCRIPTION
`CountryComparator` takes two countries: A and B.

It should return -1 if A precedes B, 0 if A is equal to B and 1 if B precedes A.

It can be used in SelectorConfig to sort the country list according to the comparator.
Sorting is disabled by default.

Example:
```
selectorConfig: SelectorConfig(countryComparator: (a, b) => a.name.compareTo(b.name)),
```