### PR TITLE
on tap outside of Modal Sheet now dismisses the dialogue

### DIFF
--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -143,31 +143,36 @@ class SelectorButton extends StatelessWidget {
           padding:
               EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
           duration: const Duration(milliseconds: 100),
-          child: DraggableScrollableSheet(
-            builder: (BuildContext context, ScrollController controller) {
-              return Container(
-                decoration: ShapeDecoration(
-                  color: selectorConfig.backgroundColor ??
-                      Theme.of(context).canvasColor,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.only(
-                      topLeft: Radius.circular(12),
-                      topRight: Radius.circular(12),
+          child: Stack(children: [
+            GestureDetector(
+              onTap: () => Navigator.pop(context),
+            ),
+            DraggableScrollableSheet(
+              builder: (BuildContext context, ScrollController controller) {
+                return Container(
+                  decoration: ShapeDecoration(
+                    color: selectorConfig.backgroundColor ??
+                        Theme.of(context).canvasColor,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.only(
+                        topLeft: Radius.circular(12),
+                        topRight: Radius.circular(12),
+                      ),
                     ),
                   ),
-                ),
-                child: CountrySearchListWidget(
-                  countries,
-                  locale,
-                  searchBoxDecoration: searchBoxDecoration,
-                  scrollController: controller,
-                  showFlags: selectorConfig.showFlags,
-                  useEmoji: selectorConfig.useEmoji,
-                  autoFocus: autoFocusSearchField,
-                ),
-              );
-            },
-          ),
+                  child: CountrySearchListWidget(
+                    countries,
+                    locale,
+                    searchBoxDecoration: searchBoxDecoration,
+                    scrollController: controller,
+                    showFlags: selectorConfig.showFlags,
+                    useEmoji: selectorConfig.useEmoji,
+                    autoFocus: autoFocusSearchField,
+                  ),
+                );
+              },
+            ),
+          ]),
         );
       },
     );


### PR DESCRIPTION
I believe that when user clicks outside of Bottom sheet modal, they expect it to naturally close. 

I was able to make this happen by placing a stack of two widgets in `AnimatedPadding `
selector_button.dart -> `showCountrySelectorBottomSheet()`

The bottom is a `GesterDetector `which when clicked dismisses the dialogue, overlayed on that would be the `DraggableScrollSheet`

I didn't write any tests, but everything else is still working as expected. 
I feel this feature should be standard in the library without any props to enable it.

Related issues:
https://github.com/natintosh/intl_phone_number_input/issues/98#issue-696898987