### PR TITLE
Actually using cursorColor

### DIFF
--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -411,6 +411,7 @@ class _InputWidgetView
               key: Key(TestHelper.TextInputKeyValue),
               textDirection: TextDirection.ltr,
               controller: state.controller,
+              cursorColor: widget.cursorColor,
               focusNode: widget.focusNode,
               enabled: widget.isEnabled,
               autofocus: widget.autoFocus,


### PR DESCRIPTION
The `cursorColor` wasn't actually used anywhere in the code, so I simply added it to the `TextFormField` so that we can customize this.