### PR TITLE
[fix] ignore selector and text field spacing in prefixIcon mode

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,7 +59,8 @@ class _MyHomePageState extends State<MyHomePage> {
               initialValue: number,
               textFieldController: controller,
               formatInput: false,
-              keyboardType: TextInputType.numberWithOptions(signed: true, decimal: true),
+              keyboardType:
+                  TextInputType.numberWithOptions(signed: true, decimal: true),
               inputBorder: OutlineInputBorder(),
               onSaved: (PhoneNumber number) {
                 print('On Saved: $number');

--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -53,6 +53,8 @@ class InternationalPhoneNumberInput extends StatefulWidget {
   final String errorMessage;
 
   final double selectorButtonOnErrorPadding;
+
+  /// Ignored if [setSelectorButtonAsPrefixIcon = true]
   final double spaceBetweenSelectorAndTextField;
   final int maxLength;
 
@@ -382,30 +384,29 @@ class _InputWidgetView
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
-          widget.selectorConfig.setSelectorButtonAsPrefixIcon
-              ? SizedBox.shrink()
-              : Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    SelectorButton(
-                      country: state.country,
-                      countries: state.countries,
-                      onCountryChanged: state.onCountryChanged,
-                      selectorConfig: widget.selectorConfig,
-                      selectorTextStyle: widget.selectorTextStyle,
-                      searchBoxDecoration: widget.searchBoxDecoration,
-                      locale: state.locale,
-                      isEnabled: widget.isEnabled,
-                      autoFocusSearchField: widget.autoFocusSearch,
-                      isScrollControlled:
-                          widget.countrySelectorScrollControlled,
-                    ),
-                    SizedBox(
-                      height: state.selectorButtonBottomPadding,
-                    ),
-                  ],
+          if (!widget.selectorConfig.setSelectorButtonAsPrefixIcon) ...[
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                SelectorButton(
+                  country: state.country,
+                  countries: state.countries,
+                  onCountryChanged: state.onCountryChanged,
+                  selectorConfig: widget.selectorConfig,
+                  selectorTextStyle: widget.selectorTextStyle,
+                  searchBoxDecoration: widget.searchBoxDecoration,
+                  locale: state.locale,
+                  isEnabled: widget.isEnabled,
+                  autoFocusSearchField: widget.autoFocusSearch,
+                  isScrollControlled: widget.countrySelectorScrollControlled,
                 ),
-          SizedBox(width: widget.spaceBetweenSelectorAndTextField),
+                SizedBox(
+                  height: state.selectorButtonBottomPadding,
+                ),
+              ],
+            ),
+            SizedBox(width: widget.spaceBetweenSelectorAndTextField),
+          ],
           Flexible(
             child: TextFormField(
               key: Key(TestHelper.TextInputKeyValue),


### PR DESCRIPTION
Hi,

Thanks for your effort happy with the new huge update,

Minor fix to ignore selector and text field spacing in prefixIcon mode as it's not applicable anymore

**Comment:**

I would recommend merging selector related fields in SelectorConfig object, also we don't need to write "selector" in variables names too

- selectorButtonOnErrorPadding
- spaceBetweenSelectorAndTextField
- countrySelectorScrollControlled
- selectorTextStyle