### PR TITLE
Fix PhoneNumberUtil.getNumberType on mobile and web

### DIFF
--- a/lib/src/utils/phone_number/phone_number_util.dart
+++ b/lib/src/utils/phone_number/phone_number_util.dart
@@ -57,12 +57,12 @@ class PhoneNumberUtil {
   /// Returns [Future<PhoneNumberType>] type of phone number
   static Future<PhoneNumberType> getNumberType(
       {@required String phoneNumber, @required String isoCode}) async {
-    var webType = await p.PhoneNumberUtil.getNumberType(phoneNumber, isoCode);
-    var mobileType = await l.PhoneNumberUtil.getNumberType(
-        phoneNumber: phoneNumber, isoCode: isoCode);
+    final dynamic type = kIsWeb
+        ? await p.PhoneNumberUtil.getNumberType(phoneNumber, isoCode)
+        : await l.PhoneNumberUtil.getNumberType(
+            phoneNumber: phoneNumber, isoCode: isoCode);
 
-    return PhoneNumberTypeUtil.getType(
-        kIsWeb ? webType.index : mobileType.index);
+    return PhoneNumberTypeUtil.getType(type.index);
   }
 
   /// [formatAsYouType] uses Google's libphonenumber input format as you type.


### PR DESCRIPTION
`PhoneNumberUtil.getNumberType` throws an exception on mobile (and maybe on web) because the following is called on mobile which is unimplemented yet on mobile yet

https://github.com/natintosh/intl_phone_number_input/blob/f6a7b0d12e6cfec1a37c289b5c57c4134275bb03/lib/src/utils/phone_number/phone_number_util.dart#L60

To reproduce call the following on android or iOS (and maybe web too):


```dart
    final PhoneNumberType type =
        await PhoneNumber.getPhoneNumberType('+966000000000', 'SA');

```

I fixed it by checking the platform before calling `getNumberType`

Thank you