### PR TITLE
Fix Dominican Republic dial_code at country_list.dart

### DIFF
--- a/lib/src/models/country_list.dart
+++ b/lib/src/models/country_list.dart
@@ -1817,7 +1817,7 @@ class Countries {
       "alpha_3_code": "DOM",
       "en_short_name": "Dominican Republic",
       "nationality": "Dominican",
-      "dial_code": "+1849",
+      "dial_code": "+1",
       "nameTranslations": {
         "sk": "Dominikánska republika",
         "se": "Dominikána dásseváldi",


### PR DESCRIPTION
Fixes Dominican Republic dial_code at country_list. Its dial_code should be +1 but instead it is set to +1849 which is just one of the 3 area codes used within the country (+1809, +1829, +1849). 

Reference: https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Dominican_Republic