### PR TITLE
temporary hotfix for PlatformException

### DIFF
--- a/lib/src/utils/phone_number/phone_number_util.dart
+++ b/lib/src/utils/phone_number/phone_number_util.dart
@@ -15,6 +15,9 @@ class PhoneNumberUtil {
   /// Returns [Future<bool>].
   static Future<bool?> isValidNumber(
       {required String phoneNumber, required String isoCode}) async {
+    if (phoneNumber.length < 2) {
+      return false;
+    }
     return p.PhoneNumberUtil.isValidPhoneNumber(phoneNumber, isoCode);
   }
 


### PR DESCRIPTION
PlatformException thrown when isValidPhoneNumber is passed a 0 or 1 character phoneNumber parameter.

I don't know enough about the platform system to trace this issue further than here. This temporary fix stops PlatformException from being thrown for now.