### PR TITLE
Phone number validation on external changes

### DIFF
--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -141,7 +141,9 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
   void initState() {
     super.initState();
     loadCountries();
-    controller = widget.textFieldController ?? TextEditingController();
+    var controller = widget.textFieldController ?? TextEditingController();
+    controller.addListener(onChanged);
+    this.controller = controller;
     initialiseWidget();
   }
 
@@ -308,7 +310,7 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
   }
 
   /// Validate the phone number when a change occurs
-  void onChanged(String value) {
+  void onChanged() {
     phoneNumberControllerListener();
   }
 
@@ -451,7 +453,6 @@ class _InputWidgetView
                       )
                     : FilteringTextInputFormatter.digitsOnly,
               ],
-              onChanged: state.onChanged,
             ),
           )
         ],


### PR DESCRIPTION
The widget does not perform a validation when the text is changed from the exterior with the usage of the provided `TextEditingController`.

The `TextFormField.onChanged `only triggers when the text is changed using that particular text form.
