### PR TITLE
SelectorButton exposed to select just countries

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,14 +35,39 @@ class _MyHomePageState extends State<MyHomePage> {
   String initialCountry = 'NG';
   PhoneNumber number = PhoneNumber(isoCode: 'NG');
 
+  Country country;
+  List<Country> countries = CountryProvider.getCountriesData(
+      countries: ["US", "AS", "DE", "BR", "CD"]);
+
   @override
   Widget build(BuildContext context) {
+    if (country == null) country = countries[0];
     return Form(
       key: formKey,
       child: Container(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
+            SelectorButton(
+              country: country,
+              countries: countries,
+              onCountryChanged: (value) {
+                setState(() {
+                  country = value;
+                });
+              },
+              selectorConfig: SelectorConfig(
+                selectorType: PhoneInputSelectorType.BOTTOM_SHEET,
+                showNames: true,
+              ),
+              selectorTextStyle: TextStyle(color: Colors.white),
+              searchBoxDecoration:
+                  InputDecoration(labelText: 'Search country by name'),
+              locale: "US",
+              isEnabled: true,
+              autoFocusSearchField: false,
+              isScrollControlled: false,
+            ),
             InternationalPhoneNumberInput(
               onInputChanged: (PhoneNumber number) {
                 print(number.phoneNumber);

--- a/lib/intl_phone_number_input.dart
+++ b/lib/intl_phone_number_input.dart
@@ -3,3 +3,6 @@ library intl_phone_number_input;
 export 'src/utils/phone_number.dart';
 export 'src/widgets/input_widget.dart';
 export 'src/utils/selector_config.dart';
+export 'src/widgets/selector_button.dart';
+export 'src/providers/country_provider.dart';
+export 'src/models/country_model.dart';

--- a/lib/src/utils/selector_config.dart
+++ b/lib/src/utils/selector_config.dart
@@ -33,6 +33,9 @@ class SelectorConfig {
   /// Add white space for short dial code
   final bool trailingSpace;
 
+  /// Show names instead of dial codes
+  final bool showNames;
+
   const SelectorConfig({
     this.selectorType = PhoneInputSelectorType.DROPDOWN,
     this.showFlags = true,
@@ -41,5 +44,6 @@ class SelectorConfig {
     this.setSelectorButtonAsPrefixIcon = false,
     this.leadingPadding,
     this.trailingSpace = true,
+    this.showNames = false,
   });
 }

--- a/lib/src/widgets/countries_search_list_widget.dart
+++ b/lib/src/widgets/countries_search_list_widget.dart
@@ -12,13 +12,18 @@ class CountrySearchListWidget extends StatefulWidget {
   final bool autoFocus;
   final bool? showFlags;
   final bool? useEmoji;
+  final bool hideCode;
 
-  CountrySearchListWidget(this.countries, this.locale,
-      {this.searchBoxDecoration,
-      this.scrollController,
-      this.showFlags,
-      this.useEmoji,
-      this.autoFocus = false});
+  CountrySearchListWidget(
+    this.countries,
+    this.locale, {
+    this.searchBoxDecoration,
+    this.scrollController,
+    this.showFlags,
+    this.useEmoji,
+    this.autoFocus = false,
+    this.hideCode = false,
+  });
 
   @override
   _CountrySearchListWidgetState createState() =>
@@ -114,11 +119,13 @@ class _CountrySearchListWidgetState extends State<CountrySearchListWidget> {
                     alignment: AlignmentDirectional.centerStart,
                     child: Text('${getCountryName(country)}',
                         textAlign: TextAlign.start)),
-                subtitle: Align(
-                    alignment: AlignmentDirectional.centerStart,
-                    child: Text('${country.dialCode ?? ''}',
-                        textDirection: TextDirection.ltr,
-                        textAlign: TextAlign.start)),
+                subtitle: (!widget.hideCode)
+                    ? Align(
+                        alignment: AlignmentDirectional.centerStart,
+                        child: Text('${country.dialCode ?? ''}',
+                            textDirection: TextDirection.ltr,
+                            textAlign: TextAlign.start))
+                    : Container(),
                 onTap: () => Navigator.of(context).pop(country),
               );
             },

--- a/lib/src/widgets/item.dart
+++ b/lib/src/widgets/item.dart
@@ -8,7 +8,7 @@ class Item extends StatelessWidget {
   final bool? showFlag;
   final bool? useEmoji;
   final TextStyle? textStyle;
-  final bool withCountryNames;
+  final bool showNames;
   final double? leadingPadding;
   final bool trailingSpace;
 
@@ -18,16 +18,23 @@ class Item extends StatelessWidget {
     this.showFlag,
     this.useEmoji,
     this.textStyle,
-    this.withCountryNames = false,
+    this.showNames = false,
     this.leadingPadding = 12,
     this.trailingSpace = true,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    String dialCode = (country?.dialCode ?? '');
+    String strLabel = '';
+
+    if (showNames) {
+      strLabel = (country?.name ?? '');
+    } else {
+      strLabel = (country?.dialCode ?? '');
+    }
+
     if (trailingSpace) {
-      dialCode = dialCode.padRight(5, "   ");
+      strLabel = strLabel.padRight(5, "   ");
     }
     return Container(
       child: Row(
@@ -43,7 +50,7 @@ class Item extends StatelessWidget {
           ),
           SizedBox(width: 12.0),
           Text(
-            '$dialCode',
+            '$strLabel',
             textDirection: TextDirection.ltr,
             style: textStyle,
           ),

--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -48,6 +48,7 @@ class SelectorButton extends StatelessWidget {
                     leadingPadding: selectorConfig.leadingPadding,
                     trailingSpace: selectorConfig.trailingSpace,
                     textStyle: selectorTextStyle,
+                    showNames: selectorConfig.showNames,
                   ),
                   value: country,
                   items: mapCountryToDropdownItem(countries),
@@ -61,6 +62,7 @@ class SelectorButton extends StatelessWidget {
                 leadingPadding: selectorConfig.leadingPadding,
                 trailingSpace: selectorConfig.trailingSpace,
                 textStyle: selectorTextStyle,
+                showNames: selectorConfig.showNames,
               )
         : MaterialButton(
             key: Key(TestHelper.DropdownButtonKeyValue),
@@ -92,6 +94,7 @@ class SelectorButton extends StatelessWidget {
                 leadingPadding: selectorConfig.leadingPadding,
                 trailingSpace: selectorConfig.trailingSpace,
                 textStyle: selectorTextStyle,
+                showNames: selectorConfig.showNames,
               ),
             ),
           );
@@ -109,7 +112,7 @@ class SelectorButton extends StatelessWidget {
           showFlag: selectorConfig.showFlags,
           useEmoji: selectorConfig.useEmoji,
           textStyle: selectorTextStyle,
-          withCountryNames: false,
+          showNames: selectorConfig.showNames,
         ),
       );
     }).toList();
@@ -173,6 +176,7 @@ class SelectorButton extends StatelessWidget {
                   showFlags: selectorConfig.showFlags,
                   useEmoji: selectorConfig.useEmoji,
                   autoFocus: autoFocusSearchField,
+                  hideCode: selectorConfig.showNames,
                 ),
               );
             },


### PR DESCRIPTION
I believe it would be beneficial for many Apps that also require Addresses from users to use the same assets provided by your library when selecting the country. So this pull request only exposes SelectorButton widget along with ContryProvider and CountryModel enabling intl_phone_number_input to work just as a country selector. It also adds a boolean variable "showName" to the SelectorConfig so it will show country names while hiding "isoCode".

Best regards.