### PR TITLE
fix selectorConfig.trailingSpace = false has no effect

### DIFF
--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -110,6 +110,7 @@ class SelectorButton extends StatelessWidget {
           useEmoji: selectorConfig.useEmoji,
           textStyle: selectorTextStyle,
           withCountryNames: false,
+          trailingSpace: selectorConfig.trailingSpace,
         ),
       );
     }).toList();


### PR DESCRIPTION
add trailingSpace to Item in mapCountryToDropdownItem because if not specify it default as true
and effect all selectorConfig.trailingSpace = false to has no changed to UI