### PR TITLE
feat: Add property to hide flag on SelectorButton

### DIFF
--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -67,6 +67,7 @@ class InternationalPhoneNumberInput extends StatefulWidget {
   final AutovalidateMode autoValidateMode;
   final bool ignoreBlank;
   final bool countrySelectorScrollControlled;
+  final bool? selectorButtonShowFlag;
 
   final String? locale;
 
@@ -110,6 +111,7 @@ class InternationalPhoneNumberInput extends StatefulWidget {
       this.autoValidateMode = AutovalidateMode.disabled,
       this.ignoreBlank = false,
       this.countrySelectorScrollControlled = true,
+      this.selectorButtonShowFlag,
       this.locale,
       this.textStyle,
       this.selectorTextStyle,
@@ -301,6 +303,8 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
         isEnabled: widget.isEnabled,
         autoFocusSearchField: widget.autoFocusSearch,
         isScrollControlled: widget.countrySelectorScrollControlled,
+        showFlag:
+            widget.selectorButtonShowFlag ?? widget.selectorConfig.showFlags,
       ));
     }
 
@@ -408,6 +412,8 @@ class _InputWidgetView
                   isEnabled: widget.isEnabled,
                   autoFocusSearchField: widget.autoFocusSearch,
                   isScrollControlled: widget.countrySelectorScrollControlled,
+                  showFlag: widget.selectorButtonShowFlag ??
+                      widget.selectorConfig.showFlags,
                 ),
                 SizedBox(
                   height: state.selectorButtonBottomPadding,

--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -17,6 +17,7 @@ class SelectorButton extends StatelessWidget {
   final String? locale;
   final bool isEnabled;
   final bool isScrollControlled;
+  final bool showFlag;
 
   final ValueChanged<Country?> onCountryChanged;
 
@@ -32,6 +33,7 @@ class SelectorButton extends StatelessWidget {
     required this.onCountryChanged,
     required this.isEnabled,
     required this.isScrollControlled,
+    required this.showFlag,
   }) : super(key: key);
 
   @override
@@ -43,7 +45,7 @@ class SelectorButton extends StatelessWidget {
                   key: Key(TestHelper.DropdownButtonKeyValue),
                   hint: Item(
                     country: country,
-                    showFlag: selectorConfig.showFlags,
+                    showFlag: showFlag,
                     useEmoji: selectorConfig.useEmoji,
                     leadingPadding: selectorConfig.leadingPadding,
                     trailingSpace: selectorConfig.trailingSpace,
@@ -56,7 +58,7 @@ class SelectorButton extends StatelessWidget {
               )
             : Item(
                 country: country,
-                showFlag: selectorConfig.showFlags,
+                showFlag: showFlag,
                 useEmoji: selectorConfig.useEmoji,
                 leadingPadding: selectorConfig.leadingPadding,
                 trailingSpace: selectorConfig.trailingSpace,
@@ -87,7 +89,7 @@ class SelectorButton extends StatelessWidget {
               padding: const EdgeInsets.only(right: 8.0),
               child: Item(
                 country: country,
-                showFlag: selectorConfig.showFlags,
+                showFlag: showFlag,
                 useEmoji: selectorConfig.useEmoji,
                 leadingPadding: selectorConfig.leadingPadding,
                 trailingSpace: selectorConfig.trailingSpace,


### PR DESCRIPTION
# What's new

Add another property `showFlag` to hide the country flag only on the `SelectorButton`.

Fallback to `selectorConfig.showFlags` if `showFlag` is not provided.