### PR TITLE
Added Padding to prevent BottomSheet from being overlapped by keyboard

### DIFF
--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -157,32 +157,36 @@ class SelectorButton extends StatelessWidget {
           GestureDetector(
             onTap: () => Navigator.pop(context),
           ),
-          DraggableScrollableSheet(
-            builder: (BuildContext context, ScrollController controller) {
-              return Directionality(
-                textDirection: Directionality.of(inheritedContext),
-                child: Container(
-                  decoration: ShapeDecoration(
-                    color: Theme.of(context).canvasColor,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.only(
-                        topLeft: Radius.circular(12),
-                        topRight: Radius.circular(12),
+          Padding(
+            padding: EdgeInsets.only(
+                    bottom: MediaQuery.of(context).viewInsets.bottom),
+            child: DraggableScrollableSheet(
+              builder: (BuildContext context, ScrollController controller) {
+                return Directionality(
+                  textDirection: Directionality.of(inheritedContext),
+                  child: Container(
+                    decoration: ShapeDecoration(
+                      color: Theme.of(context).canvasColor,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.only(
+                          topLeft: Radius.circular(12),
+                          topRight: Radius.circular(12),
+                        ),
                       ),
                     ),
+                    child: CountrySearchListWidget(
+                      countries,
+                      locale,
+                      searchBoxDecoration: searchBoxDecoration,
+                      scrollController: controller,
+                      showFlags: selectorConfig.showFlags,
+                      useEmoji: selectorConfig.useEmoji,
+                      autoFocus: autoFocusSearchField,
+                    ),
                   ),
-                  child: CountrySearchListWidget(
-                    countries,
-                    locale,
-                    searchBoxDecoration: searchBoxDecoration,
-                    scrollController: controller,
-                    showFlags: selectorConfig.showFlags,
-                    useEmoji: selectorConfig.useEmoji,
-                    autoFocus: autoFocusSearchField,
-                  ),
-                ),
-              );
-            },
+                );
+              },
+            ),
           ),
         ]);
       },


### PR DESCRIPTION
Example project has the bug with bottom sheet being overlapped by soft keyboard. This makes country search nearly impossible.

<img src="https://user-images.githubusercontent.com/5401536/135591118-93d7a945-2084-4a3c-bc82-0688e4b621d5.jpg" width="250"/>

We had the same problem in our product, so I've fixed this by adding a bottom `Padding` based on `viewInsets`. This moves bottom sheet up when keyboard appears.

