### PR TITLE
Fix overlapping keyboard issue

### DIFF
--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -46,6 +46,7 @@ class InternationalPhoneNumberInput extends StatefulWidget {
   final String? Function(String?)? validator;
   final ValueChanged<PhoneNumber>? onSaved;
 
+  final Key? fieldKey;
   final TextEditingController? textFieldController;
   final TextInputType keyboardType;
   final TextInputAction? keyboardAction;
@@ -94,6 +95,7 @@ class InternationalPhoneNumberInput extends StatefulWidget {
       this.onFieldSubmitted,
       this.validator,
       this.onSaved,
+      this.fieldKey,
       this.textFieldController,
       this.keyboardAction,
       this.keyboardType = TextInputType.phone,
@@ -418,7 +420,7 @@ class _InputWidgetView
           ],
           Flexible(
             child: TextFormField(
-              key: Key(TestHelper.TextInputKeyValue),
+              key: widget.fieldKey ?? Key(TestHelper.TextInputKeyValue),
               textDirection: TextDirection.ltr,
               controller: state.controller,
               cursorColor: widget.cursorColor,

--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -157,32 +157,36 @@ class SelectorButton extends StatelessWidget {
           GestureDetector(
             onTap: () => Navigator.pop(context),
           ),
-          DraggableScrollableSheet(
-            builder: (BuildContext context, ScrollController controller) {
-              return Directionality(
-                textDirection: Directionality.of(inheritedContext),
-                child: Container(
-                  decoration: ShapeDecoration(
-                    color: Theme.of(context).canvasColor,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.only(
-                        topLeft: Radius.circular(12),
-                        topRight: Radius.circular(12),
+          Padding(
+            padding: EdgeInsets.only(
+                    bottom: MediaQuery.of(context).viewInsets.bottom),
+            child: DraggableScrollableSheet(
+              builder: (BuildContext context, ScrollController controller) {
+                return Directionality(
+                  textDirection: Directionality.of(inheritedContext),
+                  child: Container(
+                    decoration: ShapeDecoration(
+                      color: Theme.of(context).canvasColor,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.only(
+                          topLeft: Radius.circular(12),
+                          topRight: Radius.circular(12),
+                        ),
                       ),
                     ),
+                    child: CountrySearchListWidget(
+                      countries,
+                      locale,
+                      searchBoxDecoration: searchBoxDecoration,
+                      scrollController: controller,
+                      showFlags: selectorConfig.showFlags,
+                      useEmoji: selectorConfig.useEmoji,
+                      autoFocus: autoFocusSearchField,
+                    ),
                   ),
-                  child: CountrySearchListWidget(
-                    countries,
-                    locale,
-                    searchBoxDecoration: searchBoxDecoration,
-                    scrollController: controller,
-                    showFlags: selectorConfig.showFlags,
-                    useEmoji: selectorConfig.useEmoji,
-                    autoFocus: autoFocusSearchField,
-                  ),
-                ),
-              );
-            },
+                );
+              },
+            ),
           ),
         ]);
       },


### PR DESCRIPTION
When typing in country search field, the keyboard overlaps with search results area, making it nearly impossible to select a matching result. This PR fixes that. It also adds an optional field `Key` to input widget.

Credits @Bringoff 