### PR TITLE
Allow the customization of the bottom sheet.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -55,6 +55,9 @@ class _MyHomePageState extends State<MyHomePage> {
               },
               selectorConfig: SelectorConfig(
                 selectorType: PhoneInputSelectorType.BOTTOM_SHEET,
+                initialSheetSize: 0.7,
+                minSheetSize: 0.3,
+                maxSheetSize: 0.9,
               ),
               ignoreBlank: false,
               autoValidateMode: AutovalidateMode.disabled,

--- a/example/lib/main_bottom_sheet.dart
+++ b/example/lib/main_bottom_sheet.dart
@@ -50,6 +50,9 @@ class _MyHomePageState extends State<MyHomePage> {
               inputBorder: OutlineInputBorder(),
               selectorConfig: SelectorConfig(
                 selectorType: PhoneInputSelectorType.BOTTOM_SHEET,
+                initialSheetSize: 0.7,
+                minSheetSize: 0.3,
+                maxSheetSize: 0.9,
               ),
             ),
             ElevatedButton(

--- a/lib/src/utils/selector_config.dart
+++ b/lib/src/utils/selector_config.dart
@@ -33,6 +33,24 @@ class SelectorConfig {
   /// Add white space for short dial code
   final bool trailingSpace;
 
+  /// The initial fractional value of the parent container's height to use when
+  /// displaying the DraggableScrollableSheet.
+  ///
+  /// The default value is `0.5`.
+  final double initialSheetSize;
+
+  /// The minimum fractional value of the parent container's height to use when
+  /// displaying the DraggableScrollableSheet.
+  ///
+  /// The default value is `0.25`.
+  final double minSheetSize;
+
+  /// The maximum fractional value of the parent container's height to use when
+  /// displaying the DraggableScrollableSheet.
+  ///
+  /// The default value is `1.0`.
+  final double maxSheetSize;
+
   const SelectorConfig({
     this.selectorType = PhoneInputSelectorType.DROPDOWN,
     this.showFlags = true,
@@ -41,5 +59,8 @@ class SelectorConfig {
     this.setSelectorButtonAsPrefixIcon = false,
     this.leadingPadding,
     this.trailingSpace = true,
+    this.initialSheetSize = 0.5,
+    this.minSheetSize = 0.25,
+    this.maxSheetSize = 1.0,
   });
 }

--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -158,6 +158,9 @@ class SelectorButton extends StatelessWidget {
             onTap: () => Navigator.pop(context),
           ),
           DraggableScrollableSheet(
+            initialChildSize: selectorConfig.initialSheetSize,
+            minChildSize: selectorConfig.minSheetSize,
+            maxChildSize: selectorConfig.maxSheetSize,
             builder: (BuildContext context, ScrollController controller) {
               return Directionality(
                 textDirection: Directionality.of(inheritedContext),


### PR DESCRIPTION
In the selector button for the bottom sheet, we needed to customise the height of the bottom sheet because in some devices it was hard to see the items since the keyboard was covered  them. 
