### PR TITLE
Export country_model in intl_phone_number_input.dart

### DIFF
--- a/lib/intl_phone_number_input.dart
+++ b/lib/intl_phone_number_input.dart
@@ -3,3 +3,4 @@ library intl_phone_number_input;
 export 'src/utils/phone_number.dart';
 export 'src/widgets/input_widget.dart';
 export 'src/utils/selector_config.dart';
+export 'src/models/country_model.dart';


### PR DESCRIPTION
In order to be able to use `countryComparator` (see snippet below) with `Specify type annotations` [always_specify_types](https://dart-lang.github.io/linter/lints/always_specify_types.html) in our lint rules, I have to use the import from `import 'package:intl_phone_number_input/src/models/country_model.dart';`

Importing a file like `country_model.dart` leads me to the next lint error.
Don't import implementation files from another package [implementation_imports](https://dart-lang.github.io/linter/lints/implementation_imports.html)

```
 countryComparator: (Country a, Country b) {
    return a.nameTranslations!.entries
        .firstWhere((MapEntry<String, String> element) => element.key == context.locale.toString())
        .value
        .replaceFirst('Ö', 'OE')
        .replaceFirst('Ä', 'AE')
        .replaceFirst('Ü', 'UE')
        .compareTo(
          b.nameTranslations!.entries
              .firstWhere((MapEntry<String, String> element) => element.key == context.locale.toString())
              .value
              .replaceFirst('Ö', 'OE')
              .replaceFirst('Ä', 'AE')
              .replaceFirst('Ü', 'UE'),
        );
  },
```

So the solution (in my own experience, maybe there is already a better one?) would be, to add the `country_model.dart` in `..\intl_phone_number_input-0.7.0+2\lib\intl_phone_number_input.dart` as an export.

```
library intl_phone_number_input;

export 'src/utils/phone_number.dart';
export 'src/widgets/input_widget.dart';
export 'src/utils/selector_config.dart';
export 'src/models/country_model.dart';
```
