### PR TITLE
remove unnecessary country reload (since default country is selected)

### DIFF
--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -166,7 +166,6 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
       if (country!.alpha2Code != widget.initialValue?.isoCode) {
         loadCountries();
       }
-      initialiseWidget();
     }
     super.didUpdateWidget(oldWidget);
   }

--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -162,11 +162,6 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
   @override
   void didUpdateWidget(InternationalPhoneNumberInput oldWidget) {
     loadCountries(previouslySelectedCountry: country);
-    if (oldWidget.initialValue?.hash != widget.initialValue?.hash) {
-      if (country!.alpha2Code != widget.initialValue?.isoCode) {
-        loadCountries();
-      }
-    }
     super.didUpdateWidget(oldWidget);
   }
 


### PR DESCRIPTION
this pull request is intended to remove unnecessary country data reload in didUpdateWidget method, since country is already loaded in initState for its initialValue's isoCode is already loaded therefore the country is already 'pre-selected' and this made a strange behavior of the country is changing back into  it's initialValue when i try to change the country selection here's some video of the behavior (was cropped because it's a private project but i hope you get the idea)

Pre patch behavior:
https://user-images.githubusercontent.com/38610537/190352249-9c76d94f-e0be-4876-97e3-e436d8eb02c8.mp4

Post patch behavior:
https://user-images.githubusercontent.com/38610537/190352344-fb17b17b-31cd-4ac2-9a6f-b64f61cf765e.mp4

