### PR TITLE
Get ISO2Code from phone number

### DIFF
--- a/lib/src/utils/phone_number.dart
+++ b/lib/src/utils/phone_number.dart
@@ -108,7 +108,7 @@ class PhoneNumber extends Equatable {
     if (prefix.isNotEmpty) {
       prefix = prefix.startsWith('+') ? prefix : '+$prefix';
       var country = Countries.countryList
-          .firstWhereOrNull((country) => country['dial_code'] == prefix);
+          .firstWhereOrNull((country) => prefix.contains(country['dial_code']);
       if (country != null && country['alpha_2_code'] != null) {
         return country['alpha_2_code'];
       }


### PR DESCRIPTION
Instaed of passing just the prefix, you can pass the whole phone number to extract the ISOCode, this helps in case you just want to know the isocode and then build the PhoneNumber from string