### PR TITLE
remove padding, should be managed by ThemeData

### DIFF
--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -64,7 +64,6 @@ class SelectorButton extends StatelessWidget {
               )
         : MaterialButton(
             key: Key(TestHelper.DropdownButtonKeyValue),
-            padding: EdgeInsets.zero,
             minWidth: 0,
             onPressed: countries.isNotEmpty && countries.length > 1 && isEnabled
                 ? () async {


### PR DESCRIPTION
remove hardcoded padding to be able to set it up on ThemeData
example: 

```dart
    ThemeData(
      buttonTheme: ButtonThemeData(
        padding: const EdgeInsets.only(left: 10, top: 20, bottom: 20),
        shape: RoundedRectangleBorder(
          side: const BorderSide(color: Colors.grey),
          borderRadius: BorderRadius.circular(20),
        ),
      ),
    )
```