### PR TITLE
Safe area for bottom sheet country selector list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ SelectorConfig({
     this.backgroundColor,
     this.countryComparator,
     this.setSelectorButtonAsPrefixIcon = false,
+    this.useBottomSheetSafeArea = false,
 });
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -52,6 +52,7 @@ class _MyHomePageState extends State<MyHomePage> {
               },
               selectorConfig: SelectorConfig(
                 selectorType: PhoneInputSelectorType.BOTTOM_SHEET,
+                useBottomSheetSafeArea: true,
               ),
               ignoreBlank: false,
               autoValidateMode: AutovalidateMode.disabled,

--- a/example/lib/main_bottom_sheet.dart
+++ b/example/lib/main_bottom_sheet.dart
@@ -50,6 +50,7 @@ class _MyHomePageState extends State<MyHomePage> {
               inputBorder: OutlineInputBorder(),
               selectorConfig: SelectorConfig(
                 selectorType: PhoneInputSelectorType.BOTTOM_SHEET,
+                useBottomSheetSafeArea: true,
               ),
             ),
             ElevatedButton(

--- a/lib/src/utils/selector_config.dart
+++ b/lib/src/utils/selector_config.dart
@@ -33,6 +33,9 @@ class SelectorConfig {
   /// Add white space for short dial code
   final bool trailingSpace;
 
+  /// Use safe area for selectorType=BOTTOM_SHEET
+  final bool useBottomSheetSafeArea;
+
   const SelectorConfig({
     this.selectorType = PhoneInputSelectorType.DROPDOWN,
     this.showFlags = true,
@@ -41,5 +44,6 @@ class SelectorConfig {
     this.setSelectorButtonAsPrefixIcon = false,
     this.leadingPadding,
     this.trailingSpace = true,
+    this.useBottomSheetSafeArea = false,
   });
 }

--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -152,6 +152,7 @@ class SelectorButton extends StatelessWidget {
       shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.only(
               topLeft: Radius.circular(12), topRight: Radius.circular(12))),
+      useSafeArea: selectorConfig.useBottomSheetSafeArea,
       builder: (BuildContext context) {
         return Stack(children: [
           GestureDetector(


### PR DESCRIPTION
In the current lib version, there isn't any way to let the bottom_sheet country selector enable `useSafeArea`, making it unusable on mobile as the bottom sheet will go under the system bar. You can see in the video how the example is behaving on the iOS simulator. 

https://github.com/natintosh/intl_phone_number_input/assets/6149761/be308d10-a4c2-451a-b454-99fbea025029

After my changes, it will be configurable from `SelectorConfig`. Not sure if we need it really configurable or it can be true always. But as it is not configurable at all and it is not used I would stick to making it configurable to make sure that we have backward compatibility - this config property will be set to `false` by default. 

Please see the video after changes:

https://github.com/natintosh/intl_phone_number_input/assets/6149761/fe185c6e-767e-4f55-9d08-1aff7f71af90

It would close also 2 issues reported for some time #285 and #220 
