### PR TITLE
Refactoring of input_widget and validator, added ability to include padding below selector button

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/lib/src/utils/phone_number/phone_number_util.dart
+++ b/lib/src/utils/phone_number/phone_number_util.dart
@@ -6,17 +6,22 @@ class PhoneNumberUtil {
   /// [isValidNumber] checks if a [phoneNumber] is valid.
   /// Accepts [phoneNumber] and [isoCode]
   /// Returns [Future<bool>].
-  static Future<bool?> isValidNumber(
+  static Future<bool> isValidNumber(
       {required String phoneNumber, required String isoCode}) async {
     if (phoneNumber.length < 2) {
       return false;
     }
-    return p.PhoneNumberUtil.isValidPhoneNumber(phoneNumber, isoCode);
+    // The .then is needed to make sure return Future<bool>, instead of Future<bool?>. It appears
+    // that the libphonenumber_plugin packages should be returning Future<bool> anyway, but the error
+    // of returning Future<bool?> runs deep into the dependencies. So fix here until those are fixed
+    // to return false if validation result is null.
+    return p.PhoneNumberUtil.isValidPhoneNumber(phoneNumber, isoCode)
+        .then((v) => v ?? false);
   }
 
   /// [normalizePhoneNumber] normalizes a string of characters representing a phone number
   /// Accepts [phoneNumber] and [isoCode]
-  /// Returns [Future<String>]
+  /// Returns [Future<String?>]
   static Future<String?> normalizePhoneNumber(
       {required String phoneNumber, required String isoCode}) async {
     return p.PhoneNumberUtil.normalizePhoneNumber(phoneNumber, isoCode);

--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -183,7 +183,7 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
           widget.initialValue!.phoneNumber!.isNotEmpty &&
           (await PhoneNumberUtil.isValidNumber(
               phoneNumber: widget.initialValue!.phoneNumber!,
-              isoCode: widget.initialValue!.isoCode!))!) {
+              isoCode: widget.initialValue!.isoCode!))) {
         String phoneNumber =
             await PhoneNumber.getParsableNumber(widget.initialValue!);
 
@@ -233,12 +233,6 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
 
       getParsedPhoneNumber(parsedPhoneNumberString, this.country?.alpha2Code)
           .then((phoneNumber) {
-        if (phoneNumber == null) {
-          this.isValidPhone = false;
-        } else {
-          this.isValidPhone = true;
-        }
-
         if (widget.onInputChanged != null) {
           widget.onInputChanged!(PhoneNumber(
               phoneNumber: phoneNumber ??
@@ -260,14 +254,16 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
       String phoneNumber, String? isoCode) async {
     if (phoneNumber.isNotEmpty && isoCode != null) {
       try {
-        bool? isValidPhoneNumber = await PhoneNumberUtil.isValidNumber(
+        this.isValidPhone = await PhoneNumberUtil.isValidNumber(
             phoneNumber: phoneNumber, isoCode: isoCode);
 
-        if (isValidPhoneNumber!) {
+        if (this.isValidPhone) {
           return await PhoneNumberUtil.normalizePhoneNumber(
               phoneNumber: phoneNumber, isoCode: isoCode);
         }
-      } on Exception {
+        // ignore: unused_catch_clause, unused_catch_stack
+      } on Exception catch (e, s) {
+        //Keep catch clause for easier debugging in editors that can hover over e and s.
         return null;
       }
     }

--- a/lib/src/widgets/input_widget.dart
+++ b/lib/src/widgets/input_widget.dart
@@ -55,6 +55,7 @@ class InternationalPhoneNumberInput extends StatefulWidget {
   final String? hintText;
   final String? errorMessage;
 
+  final double selectorButtonBottomPadding;
   final double selectorButtonOnErrorPadding;
 
   /// Ignored if [setSelectorButtonAsPrefixIcon = true]
@@ -102,6 +103,7 @@ class InternationalPhoneNumberInput extends StatefulWidget {
       this.initialValue,
       this.hintText = 'Phone number',
       this.errorMessage = 'Invalid phone number',
+      this.selectorButtonBottomPadding = 0,
       this.selectorButtonOnErrorPadding = 24,
       this.spaceBetweenSelectorAndTextField = 12,
       this.maxLength = 15,
@@ -133,17 +135,18 @@ class InternationalPhoneNumberInput extends StatefulWidget {
 
 class _InputWidgetState extends State<InternationalPhoneNumberInput> {
   TextEditingController? controller;
-  double selectorButtonBottomPadding = 0;
+  late double selectorButtonBottomPadding;
 
   Country? country;
   List<Country> countries = [];
-  bool isNotValid = true;
+  bool isValidPhone = false;
 
   @override
   void initState() {
     super.initState();
     loadCountries();
     controller = widget.textFieldController ?? TextEditingController();
+    selectorButtonBottomPadding = widget.selectorButtonBottomPadding;
     initialiseWidget();
   }
 
@@ -231,32 +234,21 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
       getParsedPhoneNumber(parsedPhoneNumberString, this.country?.alpha2Code)
           .then((phoneNumber) {
         if (phoneNumber == null) {
-          String phoneNumber =
-              '${this.country?.dialCode}$parsedPhoneNumberString';
-
-          if (widget.onInputChanged != null) {
-            widget.onInputChanged!(PhoneNumber(
-                phoneNumber: phoneNumber,
-                isoCode: this.country?.alpha2Code,
-                dialCode: this.country?.dialCode));
-          }
-
-          if (widget.onInputValidated != null) {
-            widget.onInputValidated!(false);
-          }
-          this.isNotValid = true;
+          this.isValidPhone = false;
         } else {
-          if (widget.onInputChanged != null) {
-            widget.onInputChanged!(PhoneNumber(
-                phoneNumber: phoneNumber,
-                isoCode: this.country?.alpha2Code,
-                dialCode: this.country?.dialCode));
-          }
+          this.isValidPhone = true;
+        }
 
-          if (widget.onInputValidated != null) {
-            widget.onInputValidated!(true);
-          }
-          this.isNotValid = false;
+        if (widget.onInputChanged != null) {
+          widget.onInputChanged!(PhoneNumber(
+              phoneNumber: phoneNumber ??
+                  '${this.country?.dialCode}$parsedPhoneNumberString',
+              isoCode: this.country?.alpha2Code,
+              dialCode: this.country?.dialCode));
+        }
+
+        if (widget.onInputValidated != null) {
+          widget.onInputValidated!(this.isValidPhone);
         }
       });
     }
@@ -318,22 +310,22 @@ class _InputWidgetState extends State<InternationalPhoneNumberInput> {
   ///
   /// Also updates [selectorButtonBottomPadding]
   String? validator(String? value) {
-    bool isValid =
-        this.isNotValid && (value!.isNotEmpty || widget.ignoreBlank == false);
+    bool isValidInput =
+        this.isValidPhone && (value!.isNotEmpty || widget.ignoreBlank == false);
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      if (isValid && widget.errorMessage != null) {
+      if (!isValidInput && widget.errorMessage != null) {
         setState(() {
           this.selectorButtonBottomPadding =
               widget.selectorButtonOnErrorPadding;
         });
       } else {
         setState(() {
-          this.selectorButtonBottomPadding = 0;
+          this.selectorButtonBottomPadding = widget.selectorButtonBottomPadding;
         });
       }
     });
 
-    return isValid ? widget.errorMessage : null;
+    return !isValidInput ? widget.errorMessage : null;
   }
 
   /// Changes Selector Button Country and Validate Change.


### PR DESCRIPTION
I cleaned up the logic dealing with validation of input_widget, addressing the following: https://github.com/natintosh/intl_phone_number_input/issues/385

As part of cleaning up the logic, I fixed the return type of the phone number utils validator (isValidNumber). The native code returns a boolean, so it should never be null anyway.

I added the ability to add padding below the country selector. This allows a consumer to fix an issue where the flag--when not used as a prefix icon--would jump up when a phone number validation error message displayed and caused the TextField to grow in height. The flag would jump up because more padding is added when the input_widget is in the error state. The consumer can now add padding and follow the work-around listed here (https://github.com/flutter/flutter/issues/15400#issuecomment-475773473) to keep both the flag and the phone input field fixed when error messages are displayed.

Some updates to the gradle version in the example also.