### PR TITLE
Fixed bug in AsYouTypeFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.7.5]
+* Fixed bug in `AsYouTypeFormatter` that could throw a `RangeError` if the user typed non digit characters
+
 ## [0.7.4]
 * Updated minimum os version on iOS
 * Updated dependencies

--- a/lib/src/utils/formatter/as_you_type_formatter.dart
+++ b/lib/src/utils/formatter/as_you_type_formatter.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/services.dart';
 import 'package:intl_phone_number_input/src/utils/phone_number/phone_number_util.dart';
 
@@ -38,61 +40,69 @@ class AsYouTypeFormatter extends TextInputFormatter {
     if (newValueLength > 0 && newValueLength > oldValueLength) {
       String newValueText = newValue.text;
       String rawText = newValueText.replaceAll(separatorChars, '');
-      String textToParse = dialCode + rawText;
 
-      final _ = newValueText
-          .substring(
-              oldValue.selection.start == -1 ? 0 : oldValue.selection.start,
-              newValue.selection.end == -1 ? 0 : newValue.selection.end)
-          .replaceAll(separatorChars, '');
+      int rawCursorPosition = newValue.selection.end;
+
+      int digitsBeforeCursor = 0, digitsAfterCursor = 0;
+
+      if (rawCursorPosition > 0 && rawCursorPosition <= newValueText.length) {
+        final rawTextBeforeCursor = newValueText
+            .substring(0, rawCursorPosition)
+            .replaceAll(separatorChars, '');
+        final rawTextAfterCursor = newValueText
+            .substring(rawCursorPosition)
+            .replaceAll(separatorChars, '');
+
+        digitsBeforeCursor = rawTextBeforeCursor.length;
+        digitsAfterCursor = rawTextAfterCursor.length;
+      }
+
+      String textToParse = dialCode + rawText;
 
       formatAsYouType(input: textToParse).then(
         (String? value) {
           String parsedText = parsePhoneNumber(value);
 
-          int offset =
-              newValue.selection.end == -1 ? 0 : newValue.selection.end;
+          int newCursorPosition = 0;
 
-          if (separatorChars.hasMatch(parsedText)) {
-            String valueInInputIndex = parsedText[offset - 1];
+          if (digitsBeforeCursor > 0 || digitsAfterCursor > 0) {
+            for (var i = 0; i < parsedText.length; i++) {
+              final startCursor = i;
 
-            if (offset < parsedText.length) {
-              int offsetDifference = parsedText.length - offset;
-
-              if (offsetDifference < 2) {
-                if (separatorChars.hasMatch(valueInInputIndex)) {
-                  offset += 1;
+              if (allowedChars.hasMatch(parsedText[startCursor])) {
+                if (digitsBeforeCursor > 0) {
+                  digitsBeforeCursor--;
                 } else {
-                  bool isLastChar;
-                  try {
-                    var _ = newValueText[newValue.selection.end];
-                    isLastChar = false;
-                  } on RangeError {
-                    isLastChar = true;
-                  }
-                  if (isLastChar) {
-                    offset += offsetDifference;
-                  }
+                  newCursorPosition = startCursor + 1;
+                  break;
                 }
-              } else {
-                if (parsedText.length > offset - 1) {
-                  if (separatorChars.hasMatch(valueInInputIndex)) {
-                    offset += 1;
-                  }
+              }
+
+              final endCursor = parsedText.length - 1 - i;
+
+              if (allowedChars.hasMatch(parsedText[endCursor])) {
+                if (digitsAfterCursor > 0) {
+                  digitsAfterCursor--;
+                } else {
+                  newCursorPosition = endCursor + 1;
+                  break;
                 }
               }
             }
-
-            this.onInputFormatted(
-              TextEditingValue(
-                text: parsedText,
-                selection: TextSelection.collapsed(offset: offset),
-              ),
-            );
           }
+
+          newCursorPosition = min(max(newCursorPosition, 0), parsedText.length);
+
+          this.onInputFormatted(
+            TextEditingValue(
+              text: parsedText,
+              selection: TextSelection.collapsed(offset: newCursorPosition),
+            ),
+          );
         },
       );
     }
+
     return newValue;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intl_phone_number_input
 description: A simple and customizable flutter package for inputting phone number in intl / international format uses Google's libphonenumber.
-version: 0.7.4
+version: 0.7.5
 homepage: https://github.com/natintosh/intl-phone-number-input
 
 environment:


### PR DESCRIPTION
This PR resolves some of the issues reported in the `AsYouTypeFormatter`. The formatter now handles dynamic cursor changes better, and no longer throws a `RangeError` if the user types in non-digit characters.

This should fix #245 