### PR TITLE
fix: Removed backgroundColor from SelectorConfig in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ SelectorConfig({
     this.selectorType = PhoneInputSelectorType.DROPDOWN,
     this.showFlags = true,
     this.useEmoji = false,
-    this.backgroundColor,
     this.countryComparator,
     this.setSelectorButtonAsPrefixIcon = false,
     this.useBottomSheetSafeArea = false,


### PR DESCRIPTION
The README should reflect this recent change to the SelectorConfig. It is now set by Theme.of(context).canvasColor.